### PR TITLE
CI: remove workaround for s2geography dll install path

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -97,7 +97,6 @@ jobs:
             -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE
           cmake --build build --config Release
           cmake --install build
-          cp $CONDA_PREFIX/Library/lib/s2geography.dll $CONDA_PREFIX/Library/bin/s2geography.dll
         if: |
           steps.conda-cache.outputs.cache-hit != 'true' &&
           runner.os == 'Windows'


### PR DESCRIPTION
Fixed in https://github.com/paleolimbot/s2geography/pull/7