### PR TITLE
Add support for getting projected coordinates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 add_library(spherely MODULE
   src/geography.cpp
   src/predicates.cpp
+  src/projections.cpp
   src/spherely.cpp
   )
 

--- a/src/geography.cpp
+++ b/src/geography.cpp
@@ -244,7 +244,7 @@ void init_geography(py::module &m) {
     )pbdoc");
 
     pygeography.def("__repr__", [](const Geography &geog) {
-        s2geog::WKTWriter writer;
+        s2geog::WKTWriter writer(6);
         return writer.write_feature(geog.geog());
     });
 

--- a/src/projections.cpp
+++ b/src/projections.cpp
@@ -1,0 +1,49 @@
+#include <stdexcept>
+#include <iostream>
+
+#include <s2/s2projections.h>
+#include <s2/s2latlng.h>
+#include <s2geography.h>
+
+#include "geography.hpp"
+#include "pybind11.hpp"
+
+namespace py = pybind11;
+namespace s2geog = s2geography;
+using namespace spherely;
+
+
+std::tuple<double, double> project_mercator(py::object obj) {
+    auto geog = (static_cast<PyObjectGeography&>(obj)).as_geog_ptr();
+    if (geog->geog_type() != GeographyType::Point) {
+        throw py::value_error("test");
+    }
+    auto point = static_cast<Point*>(geog);
+    auto s2point = point->s2point();
+
+    auto projection = S2::MercatorProjection(20037508.3427892);
+    auto r2point = projection.Project(s2point);
+    double x = r2point.x();
+    double y = r2point.y();
+
+    return std::make_tuple(x, y);
+}
+
+
+void init_projections(py::module& m) {
+    // m.def("intersects", py::vectorize(&intersects), py::arg("a"), py::arg("b"),
+    //       R"pbdoc(
+    //     Returns True if A and B share any portion of space.
+
+    //     Intersects implies that overlaps, touches and within are True.
+
+    //     Parameters
+    //     ----------
+    //     a, b : :py:class:`Geography` or array_like
+    //         Geography object(s)
+
+    // )pbdoc");
+
+    m.def("project_mercator", &project_mercator);
+
+    }

--- a/src/spherely.cpp
+++ b/src/spherely.cpp
@@ -7,6 +7,8 @@ namespace py = pybind11;
 
 void init_geography(py::module&);
 void init_predicates(py::module&);
+void init_projections(py::module&);
+
 
 PYBIND11_MODULE(spherely, m) {
     m.doc() = R"pbdoc(
@@ -19,6 +21,7 @@ PYBIND11_MODULE(spherely, m) {
 
     init_geography(m);
     init_predicates(m);
+    init_projections(m);
 
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);


### PR DESCRIPTION
Just putting it here as draft PR to show what I was experimenting with (this just projects a single point at the moment). 

The reason I started looking at this is because it would be nice to get the coordinates in a certain projection for quick plotting of spherely geography objects (https://dewey.dunnington.ca/post/2022/s2-version-1.1.0/#plotting, https://github.com/r-spatial/s2/blob/76e36ae9ef1348412726e780f6a5a9e4ba0805d8/R/plot.R). 
But also in general we will want to expose methods to get all the coordinates, and then providing an option to get projected coordinates (in some basic projections that S2 supports) might be nice. 

For the plotting, we will also need to add tesselation in the process of getting the projected coordinates (to correctly represent the shortest-path-on-the-sphere in a projection that uses "straight" lines)