### PR TITLE
CI: temporarily pin conda s2geometry to 0.10

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11"]
         dev: [false]
         env:
@@ -27,7 +27,7 @@ jobs:
             python-version: "3.11"
             dev: true
           - env: ci/environment-dev.yml
-            os: macos-latest
+            os: macos-13
             python-version: "3.11"
             dev: true
           - env: ci/environment-dev.yml

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - cxx-compiler
-  - s2geometry
+  - s2geometry=0.10
   - s2geography
   - libabseil
   - cmake

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - cxx-compiler
   - cmake
   - make
-  - s2geometry
+  - s2geometry=0.10
   - libabseil
   - sphinx
   - pydata-sphinx-theme>=0.8.1


### PR DESCRIPTION
Because latest s2geography on condda-forge is not yet compatible with the latest s2geometry 0.11 (https://github.com/paleolimbot/s2geography/pull/19 already fixed, but will take a bit until that is released and propagated to conda packages)