### PR TITLE
Add binding to calculate distance between two geometries

### DIFF
--- a/src/accessors-geog.cpp
+++ b/src/accessors-geog.cpp
@@ -94,7 +94,7 @@ void init_accessors(py::module& m) {
             Geography object
         b : :py:class:`Geography` or array_like
             Geography object
-        radius : float
+        radius : float, optional
             Radius of Earth in meters, default 6,371,010
 
     )pbdoc");

--- a/src/spherely.pyi
+++ b/src/spherely.pyi
@@ -13,6 +13,8 @@ from typing import (
 import numpy as np
 import numpy.typing as npt
 
+EARTH_RADIUS_METERS: float = ...
+
 class Geography:
     def __init__(self, *args, **kwargs) -> None: ...
     @property
@@ -87,6 +89,28 @@ class _VFunc_Nin2_Nout1(Generic[_NameType, _ScalarReturnType, _ArrayReturnDType]
         self, a: npt.ArrayLike, b: Geography
     ) -> npt.NDArray[_ArrayReturnDType]: ...
 
+class _VFunc_Nin2optradius_Nout1(
+    Generic[_NameType, _ScalarReturnType, _ArrayReturnDType]
+):
+    @property
+    def __name__(self) -> _NameType: ...
+    @overload
+    def __call__(
+        self, a: Geography, b: Geography, radius: float = ...
+    ) -> _ScalarReturnType: ...
+    @overload
+    def __call__(
+        self, a: npt.ArrayLike, b: npt.ArrayLike, radius: float = ...
+    ) -> npt.NDArray[_ArrayReturnDType]: ...
+    @overload
+    def __call__(
+        self, a: Geography, b: npt.ArrayLike, radius: float = ...
+    ) -> npt.NDArray[_ArrayReturnDType]: ...
+    @overload
+    def __call__(
+        self, a: npt.ArrayLike, b: Geography, radius: float = ...
+    ) -> npt.NDArray[_ArrayReturnDType]: ...
+
 # Geography properties
 
 get_dimensions: _VFunc_Nin1_Nout1[Literal["get_dimensions"], Geography, Any]
@@ -112,6 +136,7 @@ disjoint: _VFunc_Nin2_Nout1[Literal["disjoint"], bool, bool]
 centroid: _VFunc_Nin1_Nout1[Literal["centroid"], Geography, Point]
 boundary: _VFunc_Nin1_Nout1[Literal["boundary"], Geography, Geography]
 convex_hull: _VFunc_Nin1_Nout1[Literal["convex_hull"], Geography, Polygon]
+distance: _VFunc_Nin2optradius_Nout1[Literal["distance"], float, float]
 
 # temp (remove)
 

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -1,8 +1,9 @@
 import numpy as np
+import pytest
 
 import spherely
 
-import pytest
+earth_radius_meters = 6_371_010
 
 
 @pytest.mark.parametrize(
@@ -81,3 +82,47 @@ def test_convex_hull(geog, expected) -> None:
     actual = actual[0]
     assert isinstance(actual, spherely.Polygon)
     assert spherely.equals(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "geog_a, geog_b, expected",
+    [
+        (
+            spherely.Point(0, 0),
+            spherely.Point(90, 0),
+            np.pi / 2 * spherely.EARTH_RADIUS_METERS,
+        ),
+        (
+            spherely.Point(90, 0),
+            spherely.Point(30, 90),
+            np.pi / 3 * spherely.EARTH_RADIUS_METERS,
+        ),
+        (
+            spherely.Polygon([(0, 0), (60, 30), (-30, 60)]),
+            spherely.Point(90, 0),
+            np.pi / 6 * spherely.EARTH_RADIUS_METERS,
+        ),
+    ],
+)
+def test_distance(geog_a, geog_b, expected) -> None:
+    # scalar
+    actual = spherely.distance(geog_a, geog_b)
+    assert isinstance(actual, float)
+    assert actual == pytest.approx(expected, 1e-9)
+
+    # array
+    actual = spherely.distance([geog_a], [geog_b])
+    assert isinstance(actual, np.ndarray)
+    actual = actual[0]
+    assert isinstance(actual, float)
+    assert actual == pytest.approx(expected, 1e-9)
+
+
+def test_distance_with_custom_radius() -> None:
+    actual = spherely.distance(
+        spherely.Point(90, 0),
+        spherely.Point(0, 0),
+        radius=1,
+    )
+    assert isinstance(actual, float)
+    assert actual == pytest.approx(np.pi / 2)

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -3,8 +3,6 @@ import pytest
 
 import spherely
 
-earth_radius_meters = 6_371_010
-
 
 @pytest.mark.parametrize(
     "geog, expected",


### PR DESCRIPTION
See #17 

Adds `distance()` measurement. The distance is calculated in meters per default, based on a new `EARTH_RADIUS_METERS` constant. The radius can also be customized in the call to `distance()`.