### PR TITLE
CI: migrate from provision-with-micromamba to setup-micromamba action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,11 +19,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup micromamba
-        uses: mamba-org/provision-with-micromamba@v15
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/environment.yml
           environment-name: spherely-dev
-          extra-specs: |
+          create-args: >-
             python=3.11
 
       - name: Build and install spherely

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -45,13 +45,13 @@ jobs:
         run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')"
 
       - name: Setup micromamba
-        uses: mamba-org/provision-with-micromamba@v15
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ${{ matrix.env }}
           environment-name: spherely-dev
-          cache-env: true
-          cache-env-key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ steps.get-date.outputs.today }}-${{ hashFiles( matrix.env) }}"
-          extra-specs: |
+          cache-environment: true
+          cache-environment-key: "${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ steps.get-date.outputs.today }}-${{ hashFiles( matrix.env) }}"
+          create-args: >-
             python=${{ matrix.python-version }}
 
       - name: Fetch s2geography


### PR DESCRIPTION
The https://github.com/mamba-org/provision-with-micromamba action is deprecated, and this should hopefully fix CI as well.