### PR TITLE
ENH: Added more missing predicates

### DIFF
--- a/src/predicates.cpp
+++ b/src/predicates.cpp
@@ -117,4 +117,77 @@ void init_predicates(py::module& m) {
             Geography object(s)
 
     )pbdoc");
+
+    m.def("touches",
+          py::vectorize(Predicate([](const s2geog::ShapeIndexGeography& a_index,
+                                     const s2geog::ShapeIndexGeography& b_index,
+                                     const S2BooleanOperation::Options& options) {
+              S2BooleanOperation::Options closedOptions = options;
+              closedOptions.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
+              closedOptions.set_polyline_model(S2BooleanOperation::PolylineModel::CLOSED);
+
+              S2BooleanOperation::Options openOptions = options;
+              openOptions.set_polygon_model(S2BooleanOperation::PolygonModel::OPEN);
+              openOptions.set_polyline_model(S2BooleanOperation::PolylineModel::OPEN);
+
+              return s2geog::s2_intersects(a_index, b_index, closedOptions) &&
+                     !s2geog::s2_intersects(a_index, b_index, openOptions);
+          })),
+          py::arg("a"),
+          py::arg("b"),
+          R"pbdoc(
+        Returns True if A and B intersect, but their interiors do not intersect.
+        A and B have at least one point in common, where the common point
+        lies in at least one boundary.
+
+        Parameters
+        ----------
+        a, b : :py:class:`Geography` or array_like
+            Geography object(s)
+
+    )pbdoc");
+
+    m.def("covers",
+          py::vectorize(Predicate([](const s2geog::ShapeIndexGeography& a_index,
+                                     const s2geog::ShapeIndexGeography& b_index,
+                                     const S2BooleanOperation::Options& options) {
+              S2BooleanOperation::Options closedOptions = options;
+              closedOptions.set_polyline_model(S2BooleanOperation::PolylineModel::CLOSED);
+              closedOptions.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
+
+              return s2geog::s2_contains(a_index, b_index, closedOptions);
+          })),
+          py::arg("a"),
+          py::arg("b"),
+          R"pbdoc(
+        Returns True if every point in B lies inside the interior or boundary of A.
+
+        Parameters
+        ----------
+        a, b : :py:class:`Geography` or array_like
+            Geography object(s)
+
+    )pbdoc");
+
+    m.def("covered_by",
+          py::vectorize(Predicate([](const s2geog::ShapeIndexGeography& a_index,
+                                     const s2geog::ShapeIndexGeography& b_index,
+                                     const S2BooleanOperation::Options& options) {
+              S2BooleanOperation::Options closedOptions = options;
+              closedOptions.set_polyline_model(S2BooleanOperation::PolylineModel::CLOSED);
+              closedOptions.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
+
+              return s2geog::s2_contains(b_index, a_index, closedOptions);
+          })),
+          py::arg("a"),
+          py::arg("b"),
+          R"pbdoc(
+        Returns True if every point in A lies inside the interior or boundary of B.
+
+        Parameters
+        ----------
+        a, b : :py:class:`Geography` or array_like
+            Geography object(s)
+
+    )pbdoc");
 }

--- a/src/predicates.cpp
+++ b/src/predicates.cpp
@@ -155,7 +155,7 @@ void init_predicates(py::module& m) {
           py::arg("b"),
           R"pbdoc(
         Returns True if A and B intersect, but their interiors do not intersect.
-        
+
         A and B must have at least one point in common, where the common point
         lies in at least one boundary.
 
@@ -193,7 +193,7 @@ void init_predicates(py::module& m) {
         If A and B are both polygons and share co-linear edges,
         `covers` currently returns expected results only when those
         shared edges are identical.
- 
+
     )pbdoc");
 
     m.def("covered_by",

--- a/src/predicates.cpp
+++ b/src/predicates.cpp
@@ -155,7 +155,8 @@ void init_predicates(py::module& m) {
           py::arg("b"),
           R"pbdoc(
         Returns True if A and B intersect, but their interiors do not intersect.
-        A and B have at least one point in common, where the common point
+        
+        A and B must have at least one point in common, where the common point
         lies in at least one boundary.
 
         Parameters
@@ -187,6 +188,12 @@ void init_predicates(py::module& m) {
         a, b : :py:class:`Geography` or array_like
             Geography object(s)
 
+        Notes
+        -----
+        If A and B are both polygons and share co-linear edges,
+        `covers` currently returns expected results only when those
+        shared edges are identical.
+ 
     )pbdoc");
 
     m.def("covered_by",
@@ -207,5 +214,8 @@ void init_predicates(py::module& m) {
         a, b : :py:class:`Geography` or array_like
             Geography object(s)
 
+        See Also
+        --------
+        covers
     )pbdoc");
 }

--- a/src/predicates.cpp
+++ b/src/predicates.cpp
@@ -22,6 +22,10 @@ public:
     template <class F>
     Predicate(F&& func) : m_func(std::forward<F>(func)) {}
 
+    template <class F>
+    Predicate(F&& func, const S2BooleanOperation::Options& options)
+        : m_func(std::forward<F>(func)), m_options(options) {}
+
     bool operator()(PyObjectGeography a, PyObjectGeography b) const {
         const auto& a_index = a.as_geog_ptr()->geog_index();
         const auto& b_index = b.as_geog_ptr()->geog_index();
@@ -31,6 +35,33 @@ public:
 private:
     FuncType m_func;
     S2BooleanOperation::Options m_options;
+};
+
+/*
+** A specialization of the `Predicate` class for the touches operation,
+** as two `S2BooleanOpteration::Options` objects are necessary.
+*/
+class TouchesPredicate {
+public:
+    TouchesPredicate() : m_closed_options(), m_open_options() {
+        m_closed_options.set_polyline_model(S2BooleanOperation::PolylineModel::CLOSED);
+        m_closed_options.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
+
+        m_open_options.set_polyline_model(S2BooleanOperation::PolylineModel::OPEN);
+        m_open_options.set_polygon_model(S2BooleanOperation::PolygonModel::OPEN);
+    }
+
+    bool operator()(PyObjectGeography a, PyObjectGeography b) const {
+        const auto& a_index = a.as_geog_ptr()->geog_index();
+        const auto& b_index = b.as_geog_ptr()->geog_index();
+
+        return s2geog::s2_intersects(a_index, b_index, m_closed_options) &&
+               !s2geog::s2_intersects(a_index, b_index, m_open_options);
+    }
+
+private:
+    S2BooleanOperation::Options m_closed_options;
+    S2BooleanOperation::Options m_open_options;
 };
 
 void init_predicates(py::module& m) {
@@ -119,20 +150,7 @@ void init_predicates(py::module& m) {
     )pbdoc");
 
     m.def("touches",
-          py::vectorize(Predicate([](const s2geog::ShapeIndexGeography& a_index,
-                                     const s2geog::ShapeIndexGeography& b_index,
-                                     const S2BooleanOperation::Options& options) {
-              S2BooleanOperation::Options closedOptions = options;
-              closedOptions.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
-              closedOptions.set_polyline_model(S2BooleanOperation::PolylineModel::CLOSED);
-
-              S2BooleanOperation::Options openOptions = options;
-              openOptions.set_polygon_model(S2BooleanOperation::PolygonModel::OPEN);
-              openOptions.set_polyline_model(S2BooleanOperation::PolylineModel::OPEN);
-
-              return s2geog::s2_intersects(a_index, b_index, closedOptions) &&
-                     !s2geog::s2_intersects(a_index, b_index, openOptions);
-          })),
+          py::vectorize(TouchesPredicate()),
           py::arg("a"),
           py::arg("b"),
           R"pbdoc(
@@ -147,16 +165,18 @@ void init_predicates(py::module& m) {
 
     )pbdoc");
 
-    m.def("covers",
-          py::vectorize(Predicate([](const s2geog::ShapeIndexGeography& a_index,
-                                     const s2geog::ShapeIndexGeography& b_index,
-                                     const S2BooleanOperation::Options& options) {
-              S2BooleanOperation::Options closedOptions = options;
-              closedOptions.set_polyline_model(S2BooleanOperation::PolylineModel::CLOSED);
-              closedOptions.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
+    S2BooleanOperation::Options closed_options;
+    closed_options.set_polyline_model(S2BooleanOperation::PolylineModel::CLOSED);
+    closed_options.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
 
-              return s2geog::s2_contains(a_index, b_index, closedOptions);
-          })),
+    m.def("covers",
+          py::vectorize(Predicate(
+              [](const s2geog::ShapeIndexGeography& a_index,
+                 const s2geog::ShapeIndexGeography& b_index,
+                 const S2BooleanOperation::Options& options) {
+                  return s2geog::s2_contains(a_index, b_index, options);
+              },
+              closed_options)),
           py::arg("a"),
           py::arg("b"),
           R"pbdoc(
@@ -170,15 +190,13 @@ void init_predicates(py::module& m) {
     )pbdoc");
 
     m.def("covered_by",
-          py::vectorize(Predicate([](const s2geog::ShapeIndexGeography& a_index,
-                                     const s2geog::ShapeIndexGeography& b_index,
-                                     const S2BooleanOperation::Options& options) {
-              S2BooleanOperation::Options closedOptions = options;
-              closedOptions.set_polyline_model(S2BooleanOperation::PolylineModel::CLOSED);
-              closedOptions.set_polygon_model(S2BooleanOperation::PolygonModel::CLOSED);
-
-              return s2geog::s2_contains(b_index, a_index, closedOptions);
-          })),
+          py::vectorize(Predicate(
+              [](const s2geog::ShapeIndexGeography& a_index,
+                 const s2geog::ShapeIndexGeography& b_index,
+                 const S2BooleanOperation::Options& options) {
+                  return s2geog::s2_contains(b_index, a_index, options);
+              },
+              closed_options)),
           py::arg("a"),
           py::arg("b"),
           R"pbdoc(

--- a/src/spherely.pyi
+++ b/src/spherely.pyi
@@ -130,6 +130,9 @@ equals: _VFunc_Nin2_Nout1[Literal["intersects"], bool, bool]
 contains: _VFunc_Nin2_Nout1[Literal["contains"], bool, bool]
 within: _VFunc_Nin2_Nout1[Literal["within"], bool, bool]
 disjoint: _VFunc_Nin2_Nout1[Literal["disjoint"], bool, bool]
+touches: _VFunc_Nin2_Nout1[Literal["touches"], bool, bool]
+covers: _VFunc_Nin2_Nout1[Literal["covers"], bool, bool]
+covered_by: _VFunc_Nin2_Nout1[Literal["covered_by"], bool, bool]
 
 # geography accessors
 

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -145,7 +145,8 @@ def test_touches():
     a_p = spherely.point(1.0, 1.0)
     b_p = spherely.point(1.0, 1.0)
     # Points do not have a boundary, so they cannot touch per definition
-    # This is consistent with PostGIS for example (cmp. https://postgis.net/docs/ST_Touches.html)
+    # This is consistent with PostGIS for example
+    # (cmp. https://postgis.net/docs/ST_Touches.html)
     assert not spherely.touches(a_p, b_p)
 
     b_line = spherely.linestring([(1.0, 1.0), (1.0, 2.0)])
@@ -167,50 +168,81 @@ def parent_poly():
 
 
 @pytest.fixture
-def polys_to_check_for_covers():
+def geographies_covers_contains():
+    return np.array(
+        [
+            # Basic point covers tests, outside, on boundary and interior
+            spherely.point(-120.0, 70.0),
+            spherely.point(-118.0, 41.0),
+            spherely.point(-116.0, 37.0),
+            # Basic polyline tests, crossing, on boundary and interior
+            spherely.linestring([(-120.0, 70.0), (-116.0, 37.0)]),
+            spherely.linestring([(-118.0, 41.0), (-118.0, 23.0)]),
+            spherely.linestring([(-117.0, 39.0), (-115.0, 37.0)]),
+            # Basic polygon test, crossing, shared boundary and interior
+            spherely.polygon(
+                [(-120.0, 41.0), (-120.0, 35.0), (-115.0, 35.0), (-115.0, 41.0)]
+            ),
+            # TODO: This case is currently not fully correct. Supplying a
+            # polygon `a` and `b` and checking whether `a` covers `b`,
+            # where `a` and `b` share co-linear edges only works
+            # when the edges between them are identical.
+            # An example of this breaking would be a polygon `a`,
+            # consisting of the edges AB, BC and CA and a polygon `b`,
+            # consisting of the edges AB*, B*C* and C*A, where B* and C* reside
+            # somewhere on the edge AB and BC, respectively.
+            # In this case, s2geometry tries to resolve the co-linearity by
+            # symbolic perturbation, where B* and C* are moved by
+            # an infinitesimal amount. However, the resulting geometry may then not
+            # be covered anymore, even if it would be in reality. Therefor,
+            # these tests assume identical shared edges between polygons `a` and `b`,
+            # which does work as intended.
+            spherely.polygon(
+                [(-118.0, 40.0), (-118.0, 23.0), (34.0, 23.0), (34.0, 40.0)]
+            ),
+            spherely.polygon(
+                [(-117.0, 40.0), (-117.0, 35.0), (-115.0, 35.0), (-115.0, 40.0)]
+            ),
+        ]
+    )
+
+
+@pytest.fixture
+def geographies_covers_with_labels(geographies_covers_contains):
     return (
-        np.array(
-            [
-                # Basic point covers tests, outside, on boundary and interior
-                spherely.point(-120.0, 70.0),
-                spherely.point(-118.0, 41.0),
-                spherely.point(-116.0, 37.0),
-                # Basic polyline tests, crossing, on boundary and interior
-                spherely.linestring([(-120.0, 70.0), (-116.0, 37.0)]),
-                spherely.linestring([(-118.0, 41.0), (-118.0, 23.0)]),
-                spherely.linestring([(-117.0, 39.0), (-115.0, 37.0)]),
-                # Basic polygon test, crossing, shared boundary and interior
-                spherely.polygon(
-                    [(-120.0, 41.0), (-120.0, 35.0), (-115.0, 35.0), (-115.0, 41.0)]
-                ),
-                # TODO: This case is currently not fully correct. Supplying a polygon `a` and `b` and checking
-                # whether `a` covers `b`, where `a` and `b` share co-linear edges only works when the edges
-                # between them are identical. An example of this breaking would be a polygon `a` consisting of the edges AB, BC and CA and
-                # a polygon `b` consisting of the edges AB*, B*C* and C*A, where B* and C* reside somewhere on the edge AB and BC, respectively.
-                # In this case, s2geometry tries to resolve the co-linearity by symbolic perturbation, where B* and C* are moved by an infinitesimal
-                # amount. However, the resulting geometry may then not be covered anymore, even if it would be in reality. Therefor, these tests assume
-                # identical shared edges between polygons `a` and `b`, which does work as intended.
-                spherely.polygon(
-                    [(-118.0, 40.0), (-118.0, 23.0), (34.0, 23.0), (34.0, 40.0)]
-                ),
-                spherely.polygon(
-                    [(-117.0, 40.0), (-117.0, 35.0), (-115.0, 35.0), (-115.0, 40.0)]
-                ),
-            ]
-        ),
+        geographies_covers_contains,
         np.array([False, True, True, False, True, True, False, True, True]),
     )
 
 
-def test_covers(parent_poly, polys_to_check_for_covers):
-    polys_to_check, expected_labels = polys_to_check_for_covers
+@pytest.fixture
+def geographies_contains_with_labels(geographies_covers_contains):
+    return (
+        geographies_covers_contains,
+        np.array([False, False, True, False, False, True, False, True, True]),
+    )
+
+
+@pytest.mark.skip(
+    reason="Testing whether a polygon contains a points on its boundary \
+                currently returns true, although it should be false"
+)
+def test_contains_edge_cases(parent_poly, geographies_contains_with_labels):
+    polys_to_check, expected_labels = geographies_contains_with_labels
+
+    actual = spherely.contains(parent_poly, polys_to_check)
+    np.testing.assert_array_equal(actual, expected_labels)
+
+
+def test_covers(parent_poly, geographies_covers_with_labels):
+    polys_to_check, expected_labels = geographies_covers_with_labels
 
     actual = spherely.covers(parent_poly, polys_to_check)
     np.testing.assert_array_equal(actual, expected_labels)
 
 
-def test_covered_by(parent_poly, polys_to_check_for_covers):
-    polys_to_check, expected_labels = polys_to_check_for_covers
+def test_covered_by(parent_poly, geographies_covers_with_labels):
+    polys_to_check, expected_labels = geographies_covers_with_labels
 
     actual = spherely.covered_by(polys_to_check, parent_poly)
     np.testing.assert_array_equal(actual, expected_labels)


### PR DESCRIPTION
This PR adds the remaining predicates from #17.

I would greatly appreciate your feedback @benbovy regarding `covers` and `covered_by`, as the way it is implemented now appears to mostly work, but fails when checking polygons that partly share a boundary. This is consistent with https://github.com/r-spatial/s2/blob/b495b0df53bffc7dc1ad3780fe8ac208e78cd1bf/R/s2-predicates.R#L121C1-L124C2 for example, but deviates from PostGIS IIUC (cmp. https://postgis.net/docs/ST_Covers.html). From a user perspective, I would expect the test to work.