### PR TITLE
ENH: implement __eq__ on Geography class

### DIFF
--- a/src/geography.cpp
+++ b/src/geography.cpp
@@ -8,6 +8,7 @@
 #include <s2/s2point.h>
 #include <s2/s2polygon.h>
 #include <s2geography/geography.h>
+#include <s2geography/predicates.h>
 #include <s2geography/wkt-writer.h>
 
 #include <cstddef>
@@ -247,6 +248,14 @@ void init_geography(py::module &m) {
     pygeography.def("__repr__", [](const Geography &geog) {
         s2geog::WKTWriter writer;
         return writer.write_feature(geog.geog());
+    });
+
+    pygeography.def("__eq__", [](const Geography &geog1, const Geography &geog2) {
+        s2geog::ShapeIndexGeography idx1{geog1.geog()};
+        s2geog::ShapeIndexGeography idx2{geog2.geog()};
+
+        S2BooleanOperation::Options options;
+        return s2geog::s2_equals(idx1, idx2, options);
     });
 
     // Geography properties

--- a/tests/test_geography.py
+++ b/tests/test_geography.py
@@ -98,3 +98,28 @@ def test_prepare() -> None:
 
     spherely.destroy_prepared(geog2)
     assert spherely.is_prepared(geog2) is False
+
+
+def test_equality() -> None:
+    p1 = spherely.point(1, 1)
+    p2 = spherely.point(1, 1)
+    p3 = spherely.point(2, 2)
+
+    assert p1 == p1
+    assert p1 == p2
+    assert not p1 == p3
+
+    line1 = spherely.linestring([(1, 1), (2, 2), (3, 3)])
+    line2 = spherely.linestring([(3, 3), (2, 2), (1, 1)])
+
+    assert line1 == line2
+
+    poly1 = spherely.polygon([(1, 1), (3, 1), (2, 3)])
+    poly2 = spherely.polygon([(2, 3), (1, 1), (3, 1)])
+    poly3 = spherely.polygon([(2, 3), (3, 1), (1, 1)])
+
+    assert p1 != poly1
+    assert line1 != poly1
+    assert poly1 == poly2
+    assert poly2 == poly3
+    assert poly1 == poly3


### PR DESCRIPTION
This PR resolves #48 and adds equality testing for different `Geography` objects based on their contained geometries.