### PR TITLE
Fix repr precision for latest s2geography + expose precision in to_wkt

### DIFF
--- a/src/geography.cpp
+++ b/src/geography.cpp
@@ -245,7 +245,7 @@ void init_geography(py::module &m) {
     )pbdoc");
 
     pygeography.def("__repr__", [](const Geography &geog) {
-        s2geog::WKTWriter writer;
+        s2geog::WKTWriter writer(6);
         return writer.write_feature(geog.geog());
     });
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -99,3 +99,12 @@ def test_to_wkt():
     result = spherely.to_wkt(arr)
     expected = np.array(["POINT (1.1 1.1)", "POINT (2 2)", "POINT (3 3)"], dtype=object)
     np.testing.assert_array_equal(result, expected)
+
+
+def test_to_wkt_precision():
+    arr = spherely.points([0.12345], [0.56789])
+    result = spherely.to_wkt(arr)
+    assert result[0] == "POINT (0.12345 0.56789)"
+
+    result = spherely.to_wkt(arr, precision=2)
+    assert result[0] == "POINT (0.12 0.57)"


### PR DESCRIPTION
In another PR, the tests in the dev environment are failing. 
I am not entirely sure why this changed (I thought the default was already to use the full precision. But potentially because now using `ryu` under the hood, the definition/inference of full precision has changed) 
But in any case, I think showing up to 6 values after the decimal seems more than enough for lon/lat coordinates