### PR TITLE
ENH: add pickle support for Geography

### DIFF
--- a/src/geography.cpp
+++ b/src/geography.cpp
@@ -7,6 +7,7 @@
 #include <s2/s2loop.h>
 #include <s2/s2point.h>
 #include <s2/s2polygon.h>
+#include <s2/util/coding/coder.h>
 #include <s2geography/geography.h>
 #include <s2geography/predicates.h>
 #include <s2geography/wkt-writer.h>
@@ -171,6 +172,76 @@ void Geography::extract_geog_properties() {
     }
 }
 
+py::tuple Geography::encode() const {
+    // encode geography type
+    using IntType = std::underlying_type_t<GeographyType>;
+    auto encoded_geog_type = static_cast<IntType>(geog_type());
+
+    // encode empty
+    // (note: this is already handled internally by s2geography::Geography::EncodeTagged() but
+    // there no current way to get the that information externally when/after decoding)
+    auto empty = m_is_empty;
+
+    // encode geog
+    Encoder geog_encoder;
+    s2geog::EncodeOptions encode_opts;
+    geog().EncodeTagged(&geog_encoder, encode_opts);
+
+    std::string encoded_geog;
+    encoded_geog.assign(geog_encoder.base(), geog_encoder.base() + geog_encoder.length());
+
+    // encode geog_index (if any)
+    //
+    // TODO (benbovy): s2geography decodes the index as s2geography::EncodedShapeIndexGeography
+    // whereas s2geography functions like predicates still expect s2geography::ShapeIndexGeography.
+    // I haven't figured out yet out to convert from EncodedShapeIndexGeography to
+    // ShapeIndexGeography
+    //
+    // std::string encoded_geog_index;
+
+    // if (m_s2geog_index_ptr) {
+    //     Encoder geog_index_encoder;
+    //     (*m_s2geog_index_ptr).EncodeTagged(&geog_index_encoder, encode_opts);
+
+    //     encoded_geog_index.assign(geog_index_encoder.base(), geog_index_encoder.base() +
+    //     geog_index_encoder.length());
+    // }
+
+    return py::make_tuple(encoded_geog_type, empty, py::bytes(encoded_geog));
+}
+
+Geography Geography::decode(const py::tuple &encoded) {
+    auto decoded = Geography();
+
+    // decode geography type
+    using IntType = std::underlying_type_t<GeographyType>;
+    GeographyType geog_type{encoded[0].cast<IntType>()};
+    decoded.m_geog_type = geog_type;
+
+    // decode empty
+    decoded.m_is_empty = encoded[1].cast<bool>();
+
+    // decode geog() (s2geography::Geography)
+    auto encoded_geog = encoded[2].cast<std::string>();
+    Decoder geog_decoder(encoded_geog.c_str(), encoded_geog.size());
+    decoded.m_s2geog_ptr = s2geog::Geography::DecodeTagged(&geog_decoder);
+
+    // decode geog_index() (s2geography::ShapeIndexGeography), if any
+    //
+    // TODO (benbovy): s2geography decodes the index as s2geography::EncodedShapeIndexGeography
+    // whereas s2geography functions like predicates still expect s2geography::ShapeIndexGeography.
+    // I haven't figured out yet out to convert from EncodedShapeIndexGeography to
+    // ShapeIndexGeography
+    //
+    // auto encoded_geog_index = encoded[2].cast<std::string>();
+    // if (!encoded_geog_index.empty()) {
+    //     Decoder geog_index_decoder(encoded_geog_index.c_str(), encoded_geog_index.size());
+    //     decoded.m_s2geog_index_ptr = s2geog::Geography::DecodeTagged(&geog_index_decoder);
+    // }
+
+    return decoded;
+}
+
 /*
 ** Geography properties
 */
@@ -266,6 +337,9 @@ void init_geography(py::module &m) {
         S2BooleanOperation::Options options;
         return s2geog::s2_equals(idx1, idx2, options);
     });
+
+    pygeography.def(py::pickle([](Geography &geog) { return geog.encode(); },
+                               [](py::tuple &encoded) { return Geography::decode(encoded); }));
 
     // Geography properties
 

--- a/src/geography.cpp
+++ b/src/geography.cpp
@@ -190,23 +190,6 @@ py::tuple Geography::encode() const {
     std::string encoded_geog;
     encoded_geog.assign(geog_encoder.base(), geog_encoder.base() + geog_encoder.length());
 
-    // encode geog_index (if any)
-    //
-    // TODO (benbovy): s2geography decodes the index as s2geography::EncodedShapeIndexGeography
-    // whereas s2geography functions like predicates still expect s2geography::ShapeIndexGeography.
-    // I haven't figured out yet out to convert from EncodedShapeIndexGeography to
-    // ShapeIndexGeography
-    //
-    // std::string encoded_geog_index;
-
-    // if (m_s2geog_index_ptr) {
-    //     Encoder geog_index_encoder;
-    //     (*m_s2geog_index_ptr).EncodeTagged(&geog_index_encoder, encode_opts);
-
-    //     encoded_geog_index.assign(geog_index_encoder.base(), geog_index_encoder.base() +
-    //     geog_index_encoder.length());
-    // }
-
     return py::make_tuple(encoded_geog_type, empty, py::bytes(encoded_geog));
 }
 
@@ -232,19 +215,6 @@ Geography Geography::decode(const py::tuple &encoded) {
     } else {
         decoded.m_s2geog_ptr = std::move(decoded_geog_ptr);
     }
-
-    // decode geog_index() (s2geography::ShapeIndexGeography), if any
-    //
-    // TODO (benbovy): s2geography decodes the index as s2geography::EncodedShapeIndexGeography
-    // whereas s2geography functions like predicates still expect s2geography::ShapeIndexGeography.
-    // I haven't figured out yet out to convert from EncodedShapeIndexGeography to
-    // ShapeIndexGeography
-    //
-    // auto encoded_geog_index = encoded[2].cast<std::string>();
-    // if (!encoded_geog_index.empty()) {
-    //     Decoder geog_index_decoder(encoded_geog_index.c_str(), encoded_geog_index.size());
-    //     decoded.m_s2geog_index_ptr = s2geog::Geography::DecodeTagged(&geog_index_decoder);
-    // }
 
     return decoded;
 }

--- a/src/geography.cpp
+++ b/src/geography.cpp
@@ -224,7 +224,14 @@ Geography Geography::decode(const py::tuple &encoded) {
     // decode geog() (s2geography::Geography)
     auto encoded_geog = encoded[2].cast<std::string>();
     Decoder geog_decoder(encoded_geog.c_str(), encoded_geog.size());
-    decoded.m_s2geog_ptr = s2geog::Geography::DecodeTagged(&geog_decoder);
+    auto decoded_geog_ptr = s2geog::Geography::DecodeTagged(&geog_decoder);
+
+    // TODO: remove this quick & dirty fix (https://github.com/paleolimbot/s2geography/issues/54)
+    if (decoded_geog_ptr->kind() == s2geog::GeographyKind::GEOGRAPHY_COLLECTION) {
+        decoded.m_s2geog_ptr = clone_s2geography(*decoded_geog_ptr);
+    } else {
+        decoded.m_s2geog_ptr = std::move(decoded_geog_ptr);
+    }
 
     // decode geog_index() (s2geography::ShapeIndexGeography), if any
     //

--- a/src/geography.hpp
+++ b/src/geography.hpp
@@ -107,6 +107,9 @@ public:
     Geography clone() const;
     std::unique_ptr<s2geog::Geography> clone_geog() const;
 
+    py::tuple encode() const;
+    static Geography decode(const py::tuple& encoded);
+
 private:
     S2GeographyPtr m_s2geog_ptr;
     S2GeographyIndexPtr m_s2geog_index_ptr;

--- a/tests/test_geography.py
+++ b/tests/test_geography.py
@@ -155,11 +155,11 @@ def test_equality() -> None:
 )
 def test_pickle_roundtrip(geog):
     pickled = pickle.dumps(geog)
-    roundtriped = pickle.loads(pickled)
+    roundtripped = pickle.loads(pickled)
 
-    assert spherely.get_type_id(roundtriped) == spherely.get_type_id(geog)
-    assert spherely.to_wkt(geog) == spherely.to_wkt(roundtriped)
+    assert spherely.get_type_id(roundtripped) == spherely.get_type_id(geog)
+    assert spherely.to_wkt(geog) == spherely.to_wkt(roundtripped)
 
     # FIXME: investigate why directy equality check doesn't work with collection
     if spherely.get_type_id(geog) != spherely.GeographyType.GEOMETRYCOLLECTION.value:
-        assert roundtriped == geog
+        assert roundtripped == geog

--- a/tests/test_geography.py
+++ b/tests/test_geography.py
@@ -161,9 +161,8 @@ def test_equality() -> None:
     ],
 )
 def test_pickle_roundtrip(geog):
-    pickled = pickle.dumps(geog)
-    roundtripped = pickle.loads(pickled)
+    roundtripped = pickle.loads(pickle.dumps(geog))
 
     assert spherely.get_type_id(roundtripped) == spherely.get_type_id(geog)
-    assert spherely.to_wkt(geog) == spherely.to_wkt(roundtripped)
+    assert spherely.to_wkt(roundtripped) == spherely.to_wkt(geog)
     assert roundtripped == geog

--- a/tests/test_geography.py
+++ b/tests/test_geography.py
@@ -166,7 +166,4 @@ def test_pickle_roundtrip(geog):
 
     assert spherely.get_type_id(roundtripped) == spherely.get_type_id(geog)
     assert spherely.to_wkt(geog) == spherely.to_wkt(roundtripped)
-
-    # FIXME: see https://github.com/paleolimbot/s2geography/issues/54
-    if spherely.get_type_id(geog) != spherely.GeographyType.GEOMETRYCOLLECTION.value:
-        assert roundtripped == geog
+    assert roundtripped == geog


### PR DESCRIPTION
Closes #54.

A few comments:

- A Python tuple is used here to encode extra information that is not available or exposed from `s2geography::Geography` (i.e., the simple feature type and empty info). Alternatively, we could reuse s2geometry's Encoder / Decoder and pack everything into a single sequence of bytes, which is probably slightly more efficient, but I didn't want to mess with that and chose the easy way.

- Empty geography information is already handled internally by `s2geography::Geography::EncodeTagged` but it is not really available externally so encode it separately (that is a small amount of duplicated info, which is fine I guess).

- I thought it would be nice to also encode / decode the attached `geog_index()` if it exists, but s2geography decodes a `ShapeIndexGeography` as an `EncodedShapeIndexGeography` and I haven't figured out how we can reuse the latter (s2geography functions like predicates accept `ShapeIndexGeography`... I haven't seen yet how to convert between encoded shape index vs. shape index).

- For some reason direct equality check doesn't work with geography collections after pickle roundtrip (i.e., `roundtriped_collection == original_collection`) even though their WKT representation seem consistent. Not sure why.