### PR TITLE
Align `GeographyType` values with `shapely.GeometryType`

### DIFF
--- a/src/geography.cpp
+++ b/src/geography.cpp
@@ -291,15 +291,15 @@ void init_geography(py::module &m) {
     pygeography_types.value(
         "LINESTRING", GeographyType::LineString, "Single line geography type (1).");
     pygeography_types.value(
-        "POLYGON", GeographyType::Polygon, "Single polygon geography type (2).");
+        "POLYGON", GeographyType::Polygon, "Single polygon geography type (3).");
     pygeography_types.value(
-        "MULTIPOINT", GeographyType::MultiPoint, "Multiple point geography type (3).");
+        "MULTIPOINT", GeographyType::MultiPoint, "Multiple point geography type (4).");
     pygeography_types.value(
-        "MULTILINESTRING", GeographyType::MultiLineString, "Multiple line geography type (4).");
+        "MULTILINESTRING", GeographyType::MultiLineString, "Multiple line geography type (5).");
     pygeography_types.value(
-        "MULTIPOLYGON", GeographyType::MultiPolygon, "Multiple polygon geography type (5).");
+        "MULTIPOLYGON", GeographyType::MultiPolygon, "Multiple polygon geography type (6).");
     pygeography_types.value(
-        "GEOMETRYCOLLECTION", GeographyType::GeometryCollection, "Collection geography type (6).");
+        "GEOMETRYCOLLECTION", GeographyType::GeometryCollection, "Collection geography type (7).");
 
     // Geography classes
 

--- a/src/geography.hpp
+++ b/src/geography.hpp
@@ -24,7 +24,7 @@ enum class GeographyType : std::int8_t {
     None = -1,
     Point,
     LineString,
-    Polygon,
+    Polygon = 3,
     MultiPoint,
     MultiLineString,
     MultiPolygon,

--- a/tests/test_geography.py
+++ b/tests/test_geography.py
@@ -10,11 +10,11 @@ def test_geography_type() -> None:
     assert spherely.GeographyType.NONE.value == -1
     assert spherely.GeographyType.POINT.value == 0
     assert spherely.GeographyType.LINESTRING.value == 1
-    assert spherely.GeographyType.POLYGON.value == 2
-    assert spherely.GeographyType.MULTIPOINT.value == 3
-    assert spherely.GeographyType.MULTILINESTRING.value == 4
-    assert spherely.GeographyType.MULTIPOLYGON.value == 5
-    assert spherely.GeographyType.GEOMETRYCOLLECTION.value == 6
+    assert spherely.GeographyType.POLYGON.value == 3
+    assert spherely.GeographyType.MULTIPOINT.value == 4
+    assert spherely.GeographyType.MULTILINESTRING.value == 5
+    assert spherely.GeographyType.MULTIPOLYGON.value == 6
+    assert spherely.GeographyType.GEOMETRYCOLLECTION.value == 7
 
 
 def test_is_geography() -> None:


### PR DESCRIPTION
Closes #88.

(This is on top of #89).