### PR TITLE
Add vectorized spherely.polygons() constructor

### DIFF
--- a/src/creation.cpp
+++ b/src/creation.cpp
@@ -65,22 +65,17 @@ std::vector<S2Point> make_s2points(const std::vector<V>& points) {
     return std::move(s2points);
 }
 
-// create a S2Loop from a pre-built vector of S2Point.
+// create a S2Loop from a pre-built vector of S2Point. Callers are responsible
+// for dropping any closed-ring duplicate vertex before calling.
 //
 // Normalization (to CCW order for identifying the loop interior) and validation
 // are both enabled by default.
 //
-// If the input loop is already closed, the duplicate last vertex is dropped.
-//
 // TODO: add option to skip normalization.
 //
-std::unique_ptr<S2Loop> make_s2loop_from_points(std::vector<S2Point> s2points,
+std::unique_ptr<S2Loop> make_s2loop_from_points(const std::vector<S2Point>& s2points,
                                                 bool check = true,
                                                 bool oriented = false) {
-    if (!s2points.empty() && s2points.front() == s2points.back()) {
-        s2points.pop_back();
-    }
-
     auto loop_ptr = std::make_unique<S2Loop>();
 
     loop_ptr->set_s2debug_override(S2Debug::DISABLE);
@@ -105,13 +100,18 @@ template <class V>
 std::unique_ptr<S2Loop> make_s2loop(const std::vector<V>& vertices,
                                     bool check = true,
                                     bool oriented = false) {
-    return make_s2loop_from_points(make_s2points(vertices), check, oriented);
+    auto s2points = make_s2points(vertices);
+    if (!s2points.empty() && s2points.front() == s2points.back()) {
+        s2points.pop_back();
+    }
+    return make_s2loop_from_points(s2points, check, oriented);
 }
 
 // create a S2Polygon.
 //
 std::unique_ptr<S2Polygon> make_s2polygon(std::vector<std::unique_ptr<S2Loop>> loops,
-                                          bool oriented = false) {
+                                          bool oriented = false,
+                                          bool check = true) {
     auto polygon_ptr = std::make_unique<S2Polygon>();
     polygon_ptr->set_s2debug_override(S2Debug::DISABLE);
 
@@ -122,7 +122,7 @@ std::unique_ptr<S2Polygon> make_s2polygon(std::vector<std::unique_ptr<S2Loop>> l
     }
 
     // Note: this also checks each loop of the polygon
-    if (!polygon_ptr->IsValid()) {
+    if (check && !polygon_ptr->IsValid()) {
         std::stringstream err;
         S2Error s2err;
         err << "polygon is not valid: ";
@@ -165,7 +165,8 @@ py::array_t<PyObjectGeography> points(const py::array_t<double>& coords) {
 
 py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
                                         std::optional<std::vector<py::object>> holes,
-                                        bool oriented) {
+                                        bool oriented,
+                                        bool check) {
     auto shells_data = shells.unchecked<3>();
     if (shells_data.shape(2) != 2) {
         throw std::runtime_error("shells array must be of shape (N, K, 2)");
@@ -182,17 +183,26 @@ py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
     py::buffer_info buf = result.request();
     py::object* data = static_cast<py::object*>(buf.ptr);
 
-    // Per-ring validity is skipped (check=false); make_s2polygon's polygon-
-    // level IsValid() still catches bad rings.
+    // Scratch buffers reused across polygons and (for holes) across rings.
+    // Per-ring validity is always skipped; bad rings still surface via the
+    // polygon-level IsValid() in make_s2polygon when check=true.
+    std::vector<S2Point> pts;
+    pts.reserve(static_cast<size_t>(nverts));
+    std::vector<S2Point> hpts;
+
+    auto drop_closed = [](std::vector<S2Point>& p) {
+        if (!p.empty() && p.front() == p.back()) p.pop_back();
+    };
+
     for (py::ssize_t i = 0; i < npolys; i++) {
-        std::vector<S2Point> pts;
-        pts.reserve(static_cast<size_t>(nverts));
+        pts.clear();
         for (py::ssize_t j = 0; j < nverts; j++) {
             pts.push_back(make_s2point(shells_data(i, j, 0), shells_data(i, j, 1)));
         }
+        drop_closed(pts);
 
         std::vector<std::unique_ptr<S2Loop>> loops;
-        loops.push_back(make_s2loop_from_points(std::move(pts), /*check=*/false, oriented));
+        loops.push_back(make_s2loop_from_points(pts, /*check=*/false, oriented));
 
         if (holes.has_value()) {
             const py::object& hole_entry = (*holes)[static_cast<size_t>(i)];
@@ -207,19 +217,19 @@ py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
                 auto hk = hole_view.shape(1);
                 loops.reserve(static_cast<size_t>(1 + n_holes));
                 for (py::ssize_t h = 0; h < n_holes; h++) {
-                    std::vector<S2Point> hpts;
+                    hpts.clear();
                     hpts.reserve(static_cast<size_t>(hk));
                     for (py::ssize_t j = 0; j < hk; j++) {
                         hpts.push_back(make_s2point(hole_view(h, j, 0), hole_view(h, j, 1)));
                     }
-                    loops.push_back(
-                        make_s2loop_from_points(std::move(hpts), /*check=*/false, oriented));
+                    drop_closed(hpts);
+                    loops.push_back(make_s2loop_from_points(hpts, /*check=*/false, oriented));
                 }
             }
         }
 
-        data[i] =
-            make_py_geography<s2geog::PolygonGeography>(make_s2polygon(std::move(loops), oriented));
+        data[i] = make_py_geography<s2geog::PolygonGeography>(
+            make_s2polygon(std::move(loops), oriented, check));
     }
 
     return result;
@@ -585,7 +595,8 @@ void init_creation(py::module& m) {
           py::arg("shells"),
           py::arg("holes") = py::none(),
           py::arg("oriented") = false,
-          R"pbdoc(polygons(shells, holes=None, oriented=False)
+          py::arg("check") = true,
+          R"pbdoc(polygons(shells, holes=None, oriented=False, check=True)
 
         Create an array of polygons from a numpy array of ring coordinates.
 
@@ -612,6 +623,12 @@ void init_creation(py::module& m) {
             ring vertices are defined clockwise).
             By default (False), each ring is normalized so that the polygon
             corresponds to the smaller area on the sphere.
+        check : bool, default True
+            Validate each resulting polygon via ``S2Polygon::IsValid``. Set to
+            False only if the input polygons are known to be valid (e.g.
+            rectilinear grid cells); skipping the check is a meaningful speedup
+            on large batches but an invalid polygon will then be constructed
+            silently.
 
         Returns
         -------

--- a/src/creation.cpp
+++ b/src/creation.cpp
@@ -65,23 +65,19 @@ std::vector<S2Point> make_s2points(const std::vector<V>& points) {
     return std::move(s2points);
 }
 
-// create a S2Loop from coordinates or Point objects.
+// create a S2Loop from a pre-built vector of S2Point.
 //
 // Normalization (to CCW order for identifying the loop interior) and validation
 // are both enabled by default.
 //
-// Additional normalization is made here:
-// - if the input loop is already closed, remove one of the end nodes
+// If the input loop is already closed, the duplicate last vertex is dropped.
 //
 // TODO: add option to skip normalization.
 //
-template <class V>
-std::unique_ptr<S2Loop> make_s2loop(const std::vector<V>& vertices,
-                                    bool check = true,
-                                    bool oriented = false) {
-    auto s2points = make_s2points(vertices);
-
-    if (s2points.front() == s2points.back()) {
+std::unique_ptr<S2Loop> make_s2loop_from_points(std::vector<S2Point> s2points,
+                                                bool check = true,
+                                                bool oriented = false) {
+    if (!s2points.empty() && s2points.front() == s2points.back()) {
         s2points.pop_back();
     }
 
@@ -102,7 +98,14 @@ std::unique_ptr<S2Loop> make_s2loop(const std::vector<V>& vertices,
         loop_ptr->Normalize();
     }
 
-    return std::move(loop_ptr);
+    return loop_ptr;
+}
+
+template <class V>
+std::unique_ptr<S2Loop> make_s2loop(const std::vector<V>& vertices,
+                                    bool check = true,
+                                    bool oriented = false) {
+    return make_s2loop_from_points(make_s2points(vertices), check, oriented);
 }
 
 // create a S2Polygon.
@@ -160,40 +163,9 @@ py::array_t<PyObjectGeography> points(const py::array_t<double>& coords) {
     return points;
 }
 
-// Build a single S2Loop from a (k, 2) ring whose coordinates are produced by
-// the `get_lnglat` callable `(py::ssize_t j) -> std::pair<double, double>`.
-// Matches `make_s2loop(..., check=false, oriented)`: per-ring validity is not
-// checked here — the final polygon validity check in `make_s2polygon` will
-// surface any bad rings.
-template <class Fn>
-std::unique_ptr<S2Loop> make_s2loop_from_ring(py::ssize_t nverts, Fn&& get_lnglat, bool oriented) {
-    std::vector<S2Point> s2points;
-    s2points.reserve(static_cast<size_t>(nverts));
-    for (py::ssize_t j = 0; j < nverts; j++) {
-        auto [lng, lat] = get_lnglat(j);
-        s2points.push_back(make_s2point(lng, lat));
-    }
-
-    // Automated closing (drop the repeated last vertex).
-    if (!s2points.empty() && s2points.front() == s2points.back()) {
-        s2points.pop_back();
-    }
-
-    auto loop_ptr = std::make_unique<S2Loop>();
-    loop_ptr->set_s2debug_override(S2Debug::DISABLE);
-    loop_ptr->Init(s2points);
-    if (!oriented) {
-        loop_ptr->Normalize();
-    }
-    return loop_ptr;
-}
-
 py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
                                         std::optional<std::vector<py::object>> holes,
                                         bool oriented) {
-    if (shells.ndim() != 3) {
-        throw std::runtime_error("shells array must have 3 dimensions (N, K, 2)");
-    }
     auto shells_data = shells.unchecked<3>();
     if (shells_data.shape(2) != 2) {
         throw std::runtime_error("shells array must be of shape (N, K, 2)");
@@ -210,14 +182,17 @@ py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
     py::buffer_info buf = result.request();
     py::object* data = static_cast<py::object*>(buf.ptr);
 
+    // Per-ring validity is skipped (check=false); make_s2polygon's polygon-
+    // level IsValid() still catches bad rings.
     for (py::ssize_t i = 0; i < npolys; i++) {
+        std::vector<S2Point> pts;
+        pts.reserve(static_cast<size_t>(nverts));
+        for (py::ssize_t j = 0; j < nverts; j++) {
+            pts.push_back(make_s2point(shells_data(i, j, 0), shells_data(i, j, 1)));
+        }
+
         std::vector<std::unique_ptr<S2Loop>> loops;
-        loops.push_back(make_s2loop_from_ring(
-            nverts,
-            [&](py::ssize_t j) {
-                return std::make_pair(shells_data(i, j, 0), shells_data(i, j, 1));
-            },
-            oriented));
+        loops.push_back(make_s2loop_from_points(std::move(pts), /*check=*/false, oriented));
 
         if (holes.has_value()) {
             const py::object& hole_entry = (*holes)[static_cast<size_t>(i)];
@@ -230,22 +205,21 @@ py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
                 auto hole_view = hole_array.unchecked<3>();
                 auto n_holes = hole_view.shape(0);
                 auto hk = hole_view.shape(1);
+                loops.reserve(static_cast<size_t>(1 + n_holes));
                 for (py::ssize_t h = 0; h < n_holes; h++) {
-                    loops.push_back(make_s2loop_from_ring(
-                        hk,
-                        [&](py::ssize_t j) {
-                            return std::make_pair(hole_view(h, j, 0), hole_view(h, j, 1));
-                        },
-                        oriented));
+                    std::vector<S2Point> hpts;
+                    hpts.reserve(static_cast<size_t>(hk));
+                    for (py::ssize_t j = 0; j < hk; j++) {
+                        hpts.push_back(make_s2point(hole_view(h, j, 0), hole_view(h, j, 1)));
+                    }
+                    loops.push_back(
+                        make_s2loop_from_points(std::move(hpts), /*check=*/false, oriented));
                 }
             }
         }
 
-        // The polygon-level validity check in make_s2polygon catches bad rings
-        // too (it checks every loop), so skipping per-ring validation above is
-        // safe.
-        auto poly = make_s2polygon(std::move(loops), oriented);
-        data[i] = make_py_geography<s2geog::PolygonGeography>(std::move(poly));
+        data[i] =
+            make_py_geography<s2geog::PolygonGeography>(make_s2polygon(std::move(loops), oriented));
     }
 
     return result;

--- a/src/creation.cpp
+++ b/src/creation.cpp
@@ -13,6 +13,7 @@
 #include <s2geography/geography.h>
 
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <utility>
@@ -157,6 +158,97 @@ py::array_t<PyObjectGeography> points(const py::array_t<double>& coords) {
     }
 
     return points;
+}
+
+// Build a single S2Loop from a (k, 2) ring whose coordinates are produced by
+// the `get_lnglat` callable `(py::ssize_t j) -> std::pair<double, double>`.
+// Matches `make_s2loop(..., check=false, oriented)`: per-ring validity is not
+// checked here — the final polygon validity check in `make_s2polygon` will
+// surface any bad rings.
+template <class Fn>
+std::unique_ptr<S2Loop> make_s2loop_from_ring(py::ssize_t nverts, Fn&& get_lnglat, bool oriented) {
+    std::vector<S2Point> s2points;
+    s2points.reserve(static_cast<size_t>(nverts));
+    for (py::ssize_t j = 0; j < nverts; j++) {
+        auto [lng, lat] = get_lnglat(j);
+        s2points.push_back(make_s2point(lng, lat));
+    }
+
+    // Automated closing (drop the repeated last vertex).
+    if (!s2points.empty() && s2points.front() == s2points.back()) {
+        s2points.pop_back();
+    }
+
+    auto loop_ptr = std::make_unique<S2Loop>();
+    loop_ptr->set_s2debug_override(S2Debug::DISABLE);
+    loop_ptr->Init(s2points);
+    if (!oriented) {
+        loop_ptr->Normalize();
+    }
+    return loop_ptr;
+}
+
+py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
+                                        std::optional<std::vector<py::object>> holes,
+                                        bool oriented) {
+    if (shells.ndim() != 3) {
+        throw std::runtime_error("shells array must have 3 dimensions (N, K, 2)");
+    }
+    auto shells_data = shells.unchecked<3>();
+    if (shells_data.shape(2) != 2) {
+        throw std::runtime_error("shells array must be of shape (N, K, 2)");
+    }
+
+    auto npolys = shells_data.shape(0);
+    auto nverts = shells_data.shape(1);
+
+    if (holes.has_value() && static_cast<py::ssize_t>(holes->size()) != npolys) {
+        throw std::runtime_error("holes must be a sequence of length N (same as number of shells)");
+    }
+
+    auto result = py::array_t<PyObjectGeography>(npolys);
+    py::buffer_info buf = result.request();
+    py::object* data = static_cast<py::object*>(buf.ptr);
+
+    for (py::ssize_t i = 0; i < npolys; i++) {
+        std::vector<std::unique_ptr<S2Loop>> loops;
+        loops.push_back(make_s2loop_from_ring(
+            nverts,
+            [&](py::ssize_t j) {
+                return std::make_pair(shells_data(i, j, 0), shells_data(i, j, 1));
+            },
+            oriented));
+
+        if (holes.has_value()) {
+            const py::object& hole_entry = (*holes)[static_cast<size_t>(i)];
+            if (!hole_entry.is_none()) {
+                auto hole_array = py::cast<py::array_t<double>>(hole_entry);
+                if (hole_array.ndim() != 3 || hole_array.shape(2) != 2) {
+                    throw std::runtime_error(
+                        "each non-None entry of holes must be an array of shape (H, K, 2)");
+                }
+                auto hole_view = hole_array.unchecked<3>();
+                auto n_holes = hole_view.shape(0);
+                auto hk = hole_view.shape(1);
+                for (py::ssize_t h = 0; h < n_holes; h++) {
+                    loops.push_back(make_s2loop_from_ring(
+                        hk,
+                        [&](py::ssize_t j) {
+                            return std::make_pair(hole_view(h, j, 0), hole_view(h, j, 1));
+                        },
+                        oriented));
+                }
+            }
+        }
+
+        // The polygon-level validity check in make_s2polygon catches bad rings
+        // too (it checks every loop), so skipping per-ring validation above is
+        // safe.
+        auto poly = make_s2polygon(std::move(loops), oriented);
+        data[i] = make_py_geography<s2geog::PolygonGeography>(std::move(poly));
+    }
+
+    return result;
 }
 
 template <class V>
@@ -511,6 +603,47 @@ void init_creation(py::module& m) {
         ----------
         coords : array_like
             A array of longitude, latitude coordinate tuples (i.e., with shape (N, 2)).
+
+    )pbdoc");
+
+    m.def("polygons",
+          &polygons,
+          py::arg("shells"),
+          py::arg("holes") = py::none(),
+          py::arg("oriented") = false,
+          R"pbdoc(polygons(shells, holes=None, oriented=False)
+
+        Create an array of polygons from a numpy array of ring coordinates.
+
+        This vectorized constructor is functionally equivalent to calling
+        :py:func:`create_polygon` for each shell but avoids the per-polygon
+        Python parsing overhead, making it much faster when building many
+        polygons of uniform shape (e.g. grid cells).
+
+        Parameters
+        ----------
+        shells : array_like
+            Array of shape ``(N, K, 2)`` giving ``N`` shell rings, each with
+            ``K`` vertices expressed as ``(longitude, latitude)`` in degrees.
+            Rings may be open (first vertex not repeated as last) or closed;
+            in the latter case the duplicate closing vertex is dropped.
+        holes : sequence, optional
+            A sequence of length ``N`` where each entry is either ``None``
+            (no holes for the corresponding polygon) or an array of shape
+            ``(H, K_h, 2)`` giving that polygon's hole rings. If omitted, no
+            polygon has holes.
+        oriented : bool, default False
+            Set to True if polygon ring directions are known to be correct
+            (i.e., shell ring vertices are defined counter clockwise and hole
+            ring vertices are defined clockwise).
+            By default (False), each ring is normalized so that the polygon
+            corresponds to the smaller area on the sphere.
+
+        Returns
+        -------
+        polygons : ndarray
+            A 1-d object array of shape ``(N,)`` containing POLYGON
+            :class:`~spherely.Geography` objects.
 
     )pbdoc");
 }

--- a/src/creation.cpp
+++ b/src/creation.cpp
@@ -168,9 +168,8 @@ py::array_t<PyObjectGeography> points(const py::array_t<double>& coords) {
 }
 
 py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
-                                        std::optional<std::vector<py::object>> holes,
                                         bool oriented,
-                                        bool check) {
+                                        bool validate) {
     auto shells_data = shells.unchecked<3>();
     if (shells_data.shape(2) != 2) {
         throw std::runtime_error("shells array must be of shape (N, K, 2)");
@@ -179,20 +178,15 @@ py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
     auto npolys = shells_data.shape(0);
     auto nverts = shells_data.shape(1);
 
-    if (holes.has_value() && static_cast<py::ssize_t>(holes->size()) != npolys) {
-        throw std::runtime_error("holes must be a sequence of length N (same as number of shells)");
-    }
-
     auto result = py::array_t<PyObjectGeography>(npolys);
     py::buffer_info buf = result.request();
     py::object* data = static_cast<py::object*>(buf.ptr);
 
-    // Scratch buffers reused across polygons and (for holes) across rings.
-    // Per-ring validity is always skipped; bad rings still surface via the
-    // polygon-level IsValid() in make_s2polygon when check=true.
+    // Scratch buffer reused across polygons. Per-ring validity is always
+    // skipped; bad rings still surface via the polygon-level IsValid() in
+    // make_s2polygon when validate=true.
     std::vector<S2Point> pts;
     pts.reserve(static_cast<size_t>(nverts));
-    std::vector<S2Point> hpts;
 
     for (py::ssize_t i = 0; i < npolys; i++) {
         pts.clear();
@@ -204,32 +198,8 @@ py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
         std::vector<std::unique_ptr<S2Loop>> loops;
         loops.push_back(make_s2loop_from_points(pts, /*check=*/false, oriented));
 
-        if (holes.has_value()) {
-            const py::object& hole_entry = (*holes)[static_cast<size_t>(i)];
-            if (!hole_entry.is_none()) {
-                auto hole_array = py::cast<py::array_t<double>>(hole_entry);
-                if (hole_array.ndim() != 3 || hole_array.shape(2) != 2) {
-                    throw std::runtime_error(
-                        "each non-None entry of holes must be an array of shape (H, K, 2)");
-                }
-                auto hole_view = hole_array.unchecked<3>();
-                auto n_holes = hole_view.shape(0);
-                auto hk = hole_view.shape(1);
-                loops.reserve(static_cast<size_t>(1 + n_holes));
-                for (py::ssize_t h = 0; h < n_holes; h++) {
-                    hpts.clear();
-                    hpts.reserve(static_cast<size_t>(hk));
-                    for (py::ssize_t j = 0; j < hk; j++) {
-                        hpts.push_back(make_s2point(hole_view(h, j, 0), hole_view(h, j, 1)));
-                    }
-                    drop_closed_ring_duplicate(hpts);
-                    loops.push_back(make_s2loop_from_points(hpts, /*check=*/false, oriented));
-                }
-            }
-        }
-
         data[i] = make_py_geography<s2geog::PolygonGeography>(
-            make_s2polygon(std::move(loops), oriented, check));
+            make_s2polygon(std::move(loops), oriented, validate));
     }
 
     return result;
@@ -593,10 +563,9 @@ void init_creation(py::module& m) {
     m.def("polygons",
           &polygons,
           py::arg("shells"),
-          py::arg("holes") = py::none(),
           py::arg("oriented") = false,
-          py::arg("check") = true,
-          R"pbdoc(polygons(shells, holes=None, oriented=False, check=True)
+          py::arg("validate") = true,
+          R"pbdoc(polygons(shells, oriented=False, validate=True)
 
         Create an array of polygons from a numpy array of ring coordinates.
 
@@ -605,6 +574,12 @@ void init_creation(py::module& m) {
         Python parsing overhead, making it much faster when building many
         polygons of uniform shape (e.g. grid cells).
 
+        Limitations compared to :py:func:`create_polygon`: all polygons
+        must have the same number of shell vertices (the numpy ndarray
+        input enforces this uniformity), and holes are not supported —
+        use :py:func:`create_polygon` in a Python loop if either varies
+        across the batch.
+
         Parameters
         ----------
         shells : array_like
@@ -612,23 +587,17 @@ void init_creation(py::module& m) {
             ``K`` vertices expressed as ``(longitude, latitude)`` in degrees.
             Rings may be open (first vertex not repeated as last) or closed;
             in the latter case the duplicate closing vertex is dropped.
-        holes : sequence, optional
-            A sequence of length ``N`` where each entry is either ``None``
-            (no holes for the corresponding polygon) or an array of shape
-            ``(H, K_h, 2)`` giving that polygon's hole rings. If omitted, no
-            polygon has holes.
         oriented : bool, default False
             Set to True if polygon ring directions are known to be correct
-            (i.e., shell ring vertices are defined counter clockwise and hole
-            ring vertices are defined clockwise).
+            (i.e., shell ring vertices are defined counter clockwise).
             By default (False), each ring is normalized so that the polygon
             corresponds to the smaller area on the sphere.
-        check : bool, default True
-            Validate each resulting polygon via ``S2Polygon::IsValid``. Set to
-            False only if the input polygons are known to be valid (e.g.
-            rectilinear grid cells); skipping the check is a meaningful speedup
-            on large batches but an invalid polygon will then be constructed
-            silently.
+        validate : bool, default True
+            Validate each resulting polygon via ``S2Polygon::IsValid``. Set
+            to False only if the input polygons are known to be valid (e.g.
+            rectilinear grid cells); skipping the check is a meaningful
+            speedup on large batches but an invalid polygon will then be
+            constructed silently.
 
         Returns
         -------

--- a/src/creation.cpp
+++ b/src/creation.cpp
@@ -65,6 +65,12 @@ std::vector<S2Point> make_s2points(const std::vector<V>& points) {
     return std::move(s2points);
 }
 
+void drop_closed_ring_duplicate(std::vector<S2Point>& s2points) {
+    if (!s2points.empty() && s2points.front() == s2points.back()) {
+        s2points.pop_back();
+    }
+}
+
 // create a S2Loop from a pre-built vector of S2Point. Callers are responsible
 // for dropping any closed-ring duplicate vertex before calling.
 //
@@ -101,9 +107,7 @@ std::unique_ptr<S2Loop> make_s2loop(const std::vector<V>& vertices,
                                     bool check = true,
                                     bool oriented = false) {
     auto s2points = make_s2points(vertices);
-    if (!s2points.empty() && s2points.front() == s2points.back()) {
-        s2points.pop_back();
-    }
+    drop_closed_ring_duplicate(s2points);
     return make_s2loop_from_points(s2points, check, oriented);
 }
 
@@ -190,16 +194,12 @@ py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
     pts.reserve(static_cast<size_t>(nverts));
     std::vector<S2Point> hpts;
 
-    auto drop_closed = [](std::vector<S2Point>& p) {
-        if (!p.empty() && p.front() == p.back()) p.pop_back();
-    };
-
     for (py::ssize_t i = 0; i < npolys; i++) {
         pts.clear();
         for (py::ssize_t j = 0; j < nverts; j++) {
             pts.push_back(make_s2point(shells_data(i, j, 0), shells_data(i, j, 1)));
         }
-        drop_closed(pts);
+        drop_closed_ring_duplicate(pts);
 
         std::vector<std::unique_ptr<S2Loop>> loops;
         loops.push_back(make_s2loop_from_points(pts, /*check=*/false, oriented));
@@ -222,7 +222,7 @@ py::array_t<PyObjectGeography> polygons(const py::array_t<double>& shells,
                     for (py::ssize_t j = 0; j < hk; j++) {
                         hpts.push_back(make_s2point(hole_view(h, j, 0), hole_view(h, j, 1)));
                     }
-                    drop_closed(hpts);
+                    drop_closed_ring_duplicate(hpts);
                     loops.push_back(make_s2loop_from_points(hpts, /*check=*/false, oriented));
                 }
             }

--- a/src/spherely.pyi
+++ b/src/spherely.pyi
@@ -212,6 +212,11 @@ def create_collection(geographies: Iterable[Geography]) -> GeometryCollection: .
 def points(
     longitude: npt.ArrayLike, latitude: npt.ArrayLike
 ) -> PointGeography | T_NDArray_Geography: ...
+def polygons(
+    shells: npt.NDArray[np.float64],
+    holes: Sequence[npt.NDArray[np.float64] | None] | None = None,
+    oriented: bool = False,
+) -> T_NDArray_Geography: ...
 
 # Geography utils
 

--- a/src/spherely.pyi
+++ b/src/spherely.pyi
@@ -216,6 +216,7 @@ def polygons(
     shells: npt.NDArray[np.float64],
     holes: Sequence[npt.NDArray[np.float64] | None] | None = None,
     oriented: bool = False,
+    check: bool = True,
 ) -> T_NDArray_Geography: ...
 
 # Geography utils

--- a/src/spherely.pyi
+++ b/src/spherely.pyi
@@ -214,9 +214,8 @@ def points(
 ) -> PointGeography | T_NDArray_Geography: ...
 def polygons(
     shells: npt.NDArray[np.float64],
-    holes: Sequence[npt.NDArray[np.float64] | None] | None = None,
     oriented: bool = False,
-    check: bool = True,
+    validate: bool = True,
 ) -> T_NDArray_Geography: ...
 
 # Geography utils

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -393,33 +393,22 @@ def test_polygons_vectorized_basic() -> None:
         [
             [(0, 0), (2, 0), (2, 2), (0, 2)],
             [(4, 0), (6, 0), (6, 2), (4, 2)],
+            [(10, -5), (12, -5), (12, -3), (10, -3)],
+            [(-30, 40), (-28, 40), (-28, 42), (-30, 42)],
         ],
         dtype=np.float64,
     )
     result = spherely.polygons(shells)
 
     assert isinstance(result, np.ndarray)
-    assert result.shape == (2,)
+    assert result.shape == (4,)
     assert result.dtype == object
     assert repr(result[0]).startswith("POLYGON ((0 0")
     assert repr(result[1]).startswith("POLYGON ((4 0")
 
-
-def test_polygons_vectorized_matches_create_polygon() -> None:
-    shells = np.array(
-        [
-            [(0, 0), (2, 0), (2, 2), (0, 2)],
-            [(10, -5), (12, -5), (12, -3), (10, -3)],
-            [(-30, 40), (-28, 40), (-28, 42), (-30, 42)],
-        ],
-        dtype=np.float64,
-    )
-    vectorized = spherely.polygons(shells)
+    # each vectorized polygon matches its scalar create_polygon equivalent
     scalar = [spherely.create_polygon(ring.tolist()) for ring in shells]
-
-    assert [spherely.to_wkt(p) for p in vectorized] == [
-        spherely.to_wkt(p) for p in scalar
-    ]
+    assert [spherely.to_wkt(p) for p in result] == [spherely.to_wkt(p) for p in scalar]
 
 
 def test_polygons_vectorized_closed_ring() -> None:
@@ -451,34 +440,6 @@ def test_polygons_vectorized_oriented() -> None:
     assert repr(poly_cw) == "POLYGON ((0 0, 0 2, 2 2, 2 0, 0 0))"
 
 
-def test_polygons_vectorized_holes() -> None:
-    shells = np.array(
-        [
-            [(0, 0), (2, 0), (2, 2), (0, 2)],
-            [(4, 0), (6, 0), (6, 2), (4, 2)],
-        ],
-        dtype=np.float64,
-    )
-    hole_ring = np.array(
-        [[(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]],
-        dtype=np.float64,
-    )
-    holes = [hole_ring, None]  # second polygon has no holes
-    result = spherely.polygons(shells, holes=holes)
-
-    # holed polygon matches the scalar equivalent
-    expected = spherely.create_polygon(
-        shell=shells[0].tolist(),
-        holes=[hole_ring[0].tolist()],
-    )
-    assert spherely.to_wkt(result[0]) == spherely.to_wkt(expected)
-
-    # center of the hole is NOT inside the holed polygon
-    assert not spherely.contains(result[0], spherely.create_point(1, 1))
-    # the second polygon has no hole
-    assert spherely.contains(result[1], spherely.create_point(5, 1))
-
-
 def test_polygons_vectorized_shape_errors() -> None:
     # wrong trailing dimension
     with pytest.raises(RuntimeError, match="shape"):
@@ -487,14 +448,6 @@ def test_polygons_vectorized_shape_errors() -> None:
     # wrong number of dimensions (surfaces from pybind11's unchecked view)
     with pytest.raises(ValueError, match="number of dimensions"):
         spherely.polygons(np.zeros((4, 2), dtype=np.float64))
-
-    # holes length mismatch
-    shells = np.array(
-        [[(0, 0), (2, 0), (2, 2), (0, 2)]],
-        dtype=np.float64,
-    )
-    with pytest.raises(RuntimeError, match="length N"):
-        spherely.polygons(shells, holes=[None, None])
 
 
 def test_polygons_vectorized_invalid_ring() -> None:
@@ -511,8 +464,8 @@ def test_polygons_vectorized_invalid_ring() -> None:
         spherely.polygons(shells)
 
 
-def test_polygons_vectorized_check_false_skips_validation() -> None:
-    # same bad shell as above, but check=False must not raise.
+def test_polygons_vectorized_validate_false_skips_validation() -> None:
+    # same bad shell as above, but validate=False must not raise.
     shells = np.array(
         [
             [(0, 0), (2, 0), (2, 2), (0, 2)],
@@ -520,7 +473,7 @@ def test_polygons_vectorized_check_false_skips_validation() -> None:
         ],
         dtype=np.float64,
     )
-    result = spherely.polygons(shells, check=False)
+    result = spherely.polygons(shells, validate=False)
     # we still get a Geography back for each input; no guarantee it's valid.
     assert result.shape == (2,)
     assert all(isinstance(g, spherely.Geography) for g in result)

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -484,8 +484,8 @@ def test_polygons_vectorized_shape_errors() -> None:
     with pytest.raises(RuntimeError, match="shape"):
         spherely.polygons(np.zeros((2, 4, 3), dtype=np.float64))
 
-    # wrong number of dimensions
-    with pytest.raises(RuntimeError, match="3 dimensions"):
+    # wrong number of dimensions (surfaces from pybind11's unchecked view)
+    with pytest.raises(ValueError, match="number of dimensions"):
         spherely.polygons(np.zeros((4, 2), dtype=np.float64))
 
     # holes length mismatch

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import spherely
@@ -385,6 +386,129 @@ def test_multipolygon_invalid_geography() -> None:
         match=r"invalid Geography type \(expected POLYGON, found LINESTRING\)",
     ):
         spherely.create_multipolygon([poly, line])
+
+
+def test_polygons_vectorized_basic() -> None:
+    shells = np.array(
+        [
+            [(0, 0), (2, 0), (2, 2), (0, 2)],
+            [(4, 0), (6, 0), (6, 2), (4, 2)],
+        ],
+        dtype=np.float64,
+    )
+    result = spherely.polygons(shells)
+
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (2,)
+    assert result.dtype == object
+    assert repr(result[0]).startswith("POLYGON ((0 0")
+    assert repr(result[1]).startswith("POLYGON ((4 0")
+
+
+def test_polygons_vectorized_matches_create_polygon() -> None:
+    shells = np.array(
+        [
+            [(0, 0), (2, 0), (2, 2), (0, 2)],
+            [(10, -5), (12, -5), (12, -3), (10, -3)],
+            [(-30, 40), (-28, 40), (-28, 42), (-30, 42)],
+        ],
+        dtype=np.float64,
+    )
+    vectorized = spherely.polygons(shells)
+    scalar = [spherely.create_polygon(ring.tolist()) for ring in shells]
+
+    assert [spherely.to_wkt(p) for p in vectorized] == [
+        spherely.to_wkt(p) for p in scalar
+    ]
+
+
+def test_polygons_vectorized_closed_ring() -> None:
+    # open and closed input rings should produce the same polygon
+    open_ring = np.array(
+        [[(0, 0), (2, 0), (2, 2), (0, 2)]],
+        dtype=np.float64,
+    )
+    closed_ring = np.array(
+        [[(0, 0), (2, 0), (2, 2), (0, 2), (0, 0)]],
+        dtype=np.float64,
+    )
+    a = spherely.polygons(open_ring)[0]
+    b = spherely.polygons(closed_ring)[0]
+    assert spherely.to_wkt(a) == spherely.to_wkt(b)
+
+
+def test_polygons_vectorized_oriented() -> None:
+    # same pattern as test_polygon_oriented but using the vectorized path
+    shells = np.array(
+        [[(0, 0), (0, 2), (2, 2), (2, 0)]],
+        dtype=np.float64,
+    )
+    (poly_cw,) = spherely.polygons(shells, oriented=True)
+
+    point = spherely.create_point(1, 1)
+    # CW polygon + oriented=True => point at (1, 1) is NOT in the interior
+    assert not spherely.contains(poly_cw, point)
+    assert repr(poly_cw) == "POLYGON ((0 0, 0 2, 2 2, 2 0, 0 0))"
+
+
+def test_polygons_vectorized_holes() -> None:
+    shells = np.array(
+        [
+            [(0, 0), (2, 0), (2, 2), (0, 2)],
+            [(4, 0), (6, 0), (6, 2), (4, 2)],
+        ],
+        dtype=np.float64,
+    )
+    hole_ring = np.array(
+        [[(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)]],
+        dtype=np.float64,
+    )
+    holes = [hole_ring, None]  # second polygon has no holes
+    result = spherely.polygons(shells, holes=holes)
+
+    # holed polygon matches the scalar equivalent
+    expected = spherely.create_polygon(
+        shell=shells[0].tolist(),
+        holes=[hole_ring[0].tolist()],
+    )
+    assert spherely.to_wkt(result[0]) == spherely.to_wkt(expected)
+
+    # center of the hole is NOT inside the holed polygon
+    assert not spherely.contains(result[0], spherely.create_point(1, 1))
+    # the second polygon has no hole
+    assert spherely.contains(result[1], spherely.create_point(5, 1))
+
+
+def test_polygons_vectorized_shape_errors() -> None:
+    # wrong trailing dimension
+    with pytest.raises(RuntimeError, match="shape"):
+        spherely.polygons(np.zeros((2, 4, 3), dtype=np.float64))
+
+    # wrong number of dimensions
+    with pytest.raises(RuntimeError, match="3 dimensions"):
+        spherely.polygons(np.zeros((4, 2), dtype=np.float64))
+
+    # holes length mismatch
+    shells = np.array(
+        [[(0, 0), (2, 0), (2, 2), (0, 2)]],
+        dtype=np.float64,
+    )
+    with pytest.raises(RuntimeError, match="length N"):
+        spherely.polygons(shells, holes=[None, None])
+
+
+def test_polygons_vectorized_invalid_ring() -> None:
+    # same validation behavior as scalar create_polygon: bad rings surface as
+    # "polygon is not valid" from the final polygon-level check.
+    shells = np.array(
+        [
+            [(0, 0), (2, 0), (2, 2), (0, 2)],
+            [(0, 0), (0, 2), (0, 2), (2, 0)],  # invalid: duplicate + self-cross
+        ],
+        dtype=np.float64,
+    )
+    with pytest.raises(ValueError, match="polygon is not valid"):
+        spherely.polygons(shells)
 
 
 def test_collection() -> None:

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -511,6 +511,21 @@ def test_polygons_vectorized_invalid_ring() -> None:
         spherely.polygons(shells)
 
 
+def test_polygons_vectorized_check_false_skips_validation() -> None:
+    # same bad shell as above, but check=False must not raise.
+    shells = np.array(
+        [
+            [(0, 0), (2, 0), (2, 2), (0, 2)],
+            [(0, 0), (0, 2), (0, 2), (2, 0)],
+        ],
+        dtype=np.float64,
+    )
+    result = spherely.polygons(shells, check=False)
+    # we still get a Geography back for each input; no guarantee it's valid.
+    assert result.shape == (2,)
+    assert all(isinstance(g, spherely.Geography) for g in result)
+
+
 def test_collection() -> None:
     objs = [
         spherely.create_point(0, 0),


### PR DESCRIPTION
## Summary

Adds `spherely.polygons(shells, oriented=False, validate=True)` — a numpy-native vectorized POLYGON constructor that accepts an `(N, K, 2)` array of shell coordinates and returns a `(N,)` object array of POLYGON Geographies.

This is the batch-construction counterpart to the existing `spherely.points(coords)` and is the lane for building many polygons of uniform shape (e.g. rectilinear grid cells) without per-polygon Python call overhead.

Motivated by workloads that construct large batches of polygons with uniform ring shape — e.g. spherical regridding over a lat/lon grid — where the Python-side call overhead dominates even though the geometry itself is trivial. Refs #52.

## What's in this PR

- `src/creation.cpp`
  - New `polygons(...)` function and `m.def("polygons", ...)` binding.
  - Extracted `make_s2loop_from_points(const std::vector<S2Point>&, check, oriented)` as the shared loop-construction core; the existing `make_s2loop` template now delegates to it. Callers drop the closed-ring duplicate vertex before calling (no silent mutation).
  - `make_s2polygon` gains an optional `check` parameter that gates the `S2Polygon::IsValid()` call. Default `true` preserves all existing behavior.
  - `polygons()` reuses a single `std::vector<S2Point>` scratch buffer across polygons so the per-ring vertex allocation is amortized.
- `src/spherely.pyi` — type stub.
- `tests/test_creation.py` — 6 tests covering shape/dtype, WKT equivalence with `create_polygon`, closed-ring auto-closing, `oriented=True`, shape errors, invalid-ring error path, and `validate=False` skipping validation.

## Limitations vs `create_polygon`

Called out explicitly in the docstring:

- **All shells share the same vertex count** (enforced by the numpy `(N, K, 2)` input shape).
- **No holes** — use `create_polygon` in a Python loop if you need them. Dropped per reviewer suggestion; the grid-cell use case this PR is built around doesn't need them, and the uniform-ndarray API is a bad fit for variable hole counts anyway.

## Performance

Measured on an M-series MacBook with rectilinear (K=4) quads, best of 5 runs:

|    n    | scalar loop | vec (validate=True) | vec (validate=False) |
|---------|-------------|---------------------|----------------------|
|  10,000 |    21.9 ms  |        17.1 ms      |         8.3 ms       |
| 100,000 |   229.2 ms  |       181.2 ms      |        92.5 ms       |
| 500,000 |  1202.7 ms  |       969.0 ms      |       496.9 ms       |

- **`validate=True`:** ~1.3× vs the scalar `[create_polygon(s) for s in shells]` loop.
- **`validate=False`:** ~2.5× vs scalar, ~2× vs `validate=True`. `S2Polygon::IsValid()` is roughly half the per-polygon cost; skipping it is safe when the input is valid by construction (grid cells, pre-validated geometries).

## Test plan

- [x] All existing tests pass (full `tests/test_creation.py` — 40/40).
- [x] New tests cover shape/dtype, WKT equivalence with `create_polygon` (folded into the basic test), orientation, closed rings, the invalid-ring error path, shape-error paths, and `validate=False`.
- [x] `black`, `clang-format`, pre-commit clean on changed files.
- [x] CI across Linux/Windows/macOS.

## Review feedback addressed (commit 587e494)

- [x] Renamed `check` → `validate` (`@jorisvandenbossche`).
- [x] Dropped the `holes` parameter and its implementation.
- [x] Docstring now spells out the uniform-vertex-count + no-holes limitations.
- [x] Merged the scalar-equivalence test into the basic test.

Perf numbers above are re-measured on the post-review commit; no change to the advertised speedups.